### PR TITLE
build: Enabled build caching provided by Develocity

### DIFF
--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -33,10 +33,10 @@
   </buildScan>
   <buildCache>
     <local>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
     </local>
     <remote>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
       <storeEnabled>#{isTrue(env['JENKINS_URL'])}</storeEnabled>
     </remote>
   </buildCache>


### PR DESCRIPTION
## Description

This PR enables [build caching](https://docs.gradle.com/develocity/maven-build-cache/), which will improve both local and CI build times. 

After running local tests, we can show that build time for `mvn clean install` with the cache enabled is reduced by 81%(53s) from [1m 6s](https://ge.solutions-team.gradle.com/s/uagwoxvpv44as/performance/execution#wall-clock-time) to [12.6s](https://ge.solutions-team.gradle.com/s/qbekli5v5ya2i/performance/build#total-build-time) on my local machine. 

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Part of issue https://github.com/eclipse/mosaic/issues/466 and includes/builds on top of PR https://github.com/eclipse/mosaic/pull/467.

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.
